### PR TITLE
fix class-name display bugs in ClassBarRowComp

### DIFF
--- a/src/components/timelineComp/ClassBarRowComp/ClassBarRowComp.js
+++ b/src/components/timelineComp/ClassBarRowComp/ClassBarRowComp.js
@@ -10,7 +10,7 @@ export default class ClassBarRowComp extends Component {
       return this.props.groups.map(group => (
         <ClassRowComp      
         key={group}
-        classId={group.split(' ')[1]}
+        classId={group.replace(/ /g, '').substr(5)}
         groupsWithIds={this.props.groupsWithIds}      
         height={this.props.rowHeight}
       />

--- a/src/components/timelineComp/ClassBarRowComp/ClassRowComp/ClassRowComp.js
+++ b/src/components/timelineComp/ClassBarRowComp/ClassRowComp/ClassRowComp.js
@@ -6,9 +6,9 @@ const token = localStorage.getItem("token")
 export default class ClassRowComp extends Component {
 
     handleClassArchive = async (id) => {
-        const group = await this.props.groupsWithIds.filter(group => group.group_name.split(' ')[1] === id)
+        const group = this.props.groupsWithIds.filter(group => group.group_name.replace(/ /g, '').substr(5) === id)
 
-        if (window.confirm(`Are you sure you want to archive ${group[0].group_name} !!?`)) {
+        if (window.confirm(`Are you sure you want to archive ${group[0].group_name}?`)) {
             try {
                 await fetch(`http://localhost:3005/api/groups/${group[0].id}`, {
                     method: 'PATCH',


### PR DESCRIPTION
Fix bugs in ClassBarRowComp and ClassRowComp that were preventing class names stored without spaces from being displayed on buttons